### PR TITLE
支持 dev server headers 设置

### DIFF
--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -2,8 +2,25 @@ const { resolve } = require('path')
 
 module.exports = {
   mode: 'spa',
+  build: {
+    devMiddleware: {
+      // 这个 headers 是静态资源文件的路由，这里是 /_nuxt
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    }
+  },
   MFE: {
-    path: 'example/mfe.js'
+    force: true,
+    path: 'example/mfe.js',
+    devServer: {
+      // 写自己服务的绝对路径，斜杠结尾，必填
+      publicPath: '//localhost:3000/',
+      // 这个 headers 会通过 addServerMiddleware 注入
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    }
   },
   rootDir: resolve(__dirname, '..'),
   buildDir: resolve(__dirname, '.nuxt'),

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,0 +1,14 @@
+module.exports = (headers) => {
+  return (req, res, next) => {
+    // req 是 Node.js http request 对象
+
+    // res 是 Node.js http response 对象
+    Object.keys(headers).forEach((key) => {
+      res.setHeader(key, headers[key])
+    })
+
+    // next是一个调用下一个中间件的函数
+    // 如果您的中间件不是最终执行，请不要忘记在最后调用next！
+    next()
+  }
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,6 +2,7 @@ const { resolve } = require('path')
 const uniqueId = require('uniqid')
 const isEmpty = require('lodash.isempty')
 const { relativeTo } = require('@nuxt/utils')
+const cors = require('./cors')
 
 // Because this module override the client.js copy from v2.11.0
 // if nuxt official update client.js maybe some features won't work
@@ -31,7 +32,7 @@ module.exports = function (moduleOptions) {
 
   const usingMFE = !isEmpty(options) || MFE === true
 
-  const { path = 'mfe.js', force = false } = options
+  const { path = 'mfe.js', force = false, devServer } = options
 
   options.path = relativeTo(buildDir, path)
 
@@ -55,6 +56,11 @@ module.exports = function (moduleOptions) {
       libraryTarget: 'umd',
       jsonpFunction: `webpackJsonp_${name}`
     })
+
+    if (isDev) {
+      // dev 下默认静态资源路由 _nuxt
+      config.output.publicPath = devServer.publicPath + '_nuxt/'
+    }
   })
 
   this.addTemplate({
@@ -62,6 +68,8 @@ module.exports = function (moduleOptions) {
     fileName: 'client.js',
     options
   })
+
+  this.addServerMiddleware(cors(devServer.headers))
 
   this.nuxt.hook('build:templates', ({ templatesFiles, templateVars, resolve }) => {
     templateVars = Object.assign(templateVars, { MFE: options })

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,7 +32,7 @@ module.exports = function (moduleOptions) {
 
   const usingMFE = !isEmpty(options) || MFE === true
 
-  const { path = 'mfe.js', force = false, devServer } = options
+  const { path = 'mfe.js', force = false, devServer = {} } = options
 
   options.path = relativeTo(buildDir, path)
 
@@ -57,7 +57,7 @@ module.exports = function (moduleOptions) {
       jsonpFunction: `webpackJsonp_${name}`
     })
 
-    if (isDev) {
+    if (isDev && devServer.publicPath) {
       // dev 下默认静态资源路由 _nuxt
       config.output.publicPath = devServer.publicPath + '_nuxt/'
     }
@@ -69,7 +69,9 @@ module.exports = function (moduleOptions) {
     options
   })
 
-  this.addServerMiddleware(cors(devServer.headers))
+  if (devServer.headers) {
+    this.addServerMiddleware(cors(devServer.headers))
+  }
 
   this.nuxt.hook('build:templates', ({ templatesFiles, templateVars, resolve }) => {
     templateVars = Object.assign(templateVars, { MFE: options })


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
本地微前端开发时调试

## How
```js
...
  build: {
    devMiddleware: {
      // 这个 headers 是静态资源文件的路由，这里是 /_nuxt
      headers: {
        'Access-Control-Allow-Origin': '*'
      }
    }
  },
  MFE: {
    force: true,
    path: 'example/mfe.js',
    devServer: {
      // 写自己服务的绝对路径，斜杠结尾，必填
      publicPath: '//localhost:3000/',
      // 这个 headers 会通过 addServerMiddleware 注入
      headers: {
        'Access-Control-Allow-Origin': '*'
      }
    }
  },
...
```
