### PR TITLE
feat: 适配 qiankun 2.0 shadow dom 样式隔离模式

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -90,7 +90,7 @@ Vue.config.$nuxt.<%= globals.nuxt %> = true
 const errorHandler = Vue.config.errorHandler || console.error
 
 // Create and mount App
-const renderNuxt = () => createApp().then(mountApp).catch(errorHandler)
+const renderNuxt = (props = {}) => createApp().then((__app) => mountApp(__app, props)).catch(errorHandler)
 
 <% if (!MFE) { %>renderNuxt()<% } else {%>
 MFE.default && MFE.default(renderNuxt)
@@ -100,7 +100,7 @@ export async function bootstrap() {
 }
 
 export async function mount(props) {
-  MFE.mount && await MFE.mount(renderNuxt, props)
+  MFE.mount && await MFE.mount(() => renderNuxt(props), props)
   MFE.mounted && instance && await MFE.mounted(instance, props)
 }
 
@@ -772,7 +772,7 @@ function addHotReload ($component, depth) {
 }
 <% } %>
 
-<% if (features.layouts || features.transitions) { %>async <% } %>function mountApp (__app) {
+<% if (features.layouts || features.transitions) { %>async <% } %>function mountApp (__app, props) {
   // Set global variables
   app = __app.app
   router = __app.router
@@ -791,7 +791,9 @@ function addHotReload ($component, depth) {
 
   // Mounts Vue app to DOM element
   const mount = () => {
-    _app.$mount('#<%= globals.id %>')
+    const { container } = props
+
+    _app.$mount(container ? container.querySelector('#<%= globals.id %>') : '#<%= globals.id %>')
 
     // Add afterEach router hooks
     router.afterEach(normalizeComponents)


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
适配 qiankun 2.0 shadow dom 样式隔离模式
参考 [qiankun vue example](https://github.com/umijs/qiankun/blob/02f98ddbf8dcdb82c134035e2e9084e353c5d112/examples/vue/src/main.js#L29)

在开启 shadow-dom 隔离样式的情况下，子应用需要接收 shadow dom 的 container 以找到挂在点
e.g.
```js
start({
  prefetch: true,
  sandbox: {strictStyleIsolation: true}, // 开启基于 Shadow DOM 的样式隔离
})
```