### PR TITLE
feat: call mounted even not in qiankun

### DIFF
--- a/example/mfe.js
+++ b/example/mfe.js
@@ -1,10 +1,4 @@
 /* eslint-disable no-console */
-export default function (render) {
-  if (!window.__POWERED_BY_QIANKUN__) {
-    render()
-  }
-}
-
 // qiankun bootstrap hook
 export function bootstrap () {
   console.log('nuxt app bootstraped')
@@ -18,7 +12,7 @@ export async function mount (render, props) {
 
 // call after nuxt rendered
 export function mounted (vm) {
-  console.log(vm)
+  console.log('mounted', vm)
 }
 
 // qiankun update hook

--- a/lib/client.js
+++ b/lib/client.js
@@ -94,8 +94,13 @@ const renderNuxt = (props = {}) => createApp().then((__app) => mountApp(__app, p
 
 <% if (!MFE) { %>renderNuxt()<% } else {%>
 // prepare for rendering Nuxt app without qiankun
-if (typeof MFE.default === 'function') {
-  MFE.default(renderNuxt)
+if (!window.__POWERED_BY_QIANKUN__) {
+  renderNuxt().then(async () => {
+    if (typeof MFE.mounted === 'function' && instance) {
+      return MFE.mounted(instance, {})
+    }
+  })
+  .catch(errorHandler)
 }
 
 export async function bootstrap() {


### PR DESCRIPTION
## Why
In some ways, we will inject something from Qiankun's main application. But if runs sub-application independently, this injected object will not found. For a better compatibility, we can inject fallback functions or properties in mounted
